### PR TITLE
掲示板一覧表示機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,6 +2,7 @@ class PostsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
 
   def index
+    @posts = Post.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -34,12 +34,12 @@
                     <span>いいね数</span>
                   </li>
                 </ul>
-                <ul class="post__bottom_box__admin_actions">
                 <% if user_signed_in? && current_user.id == post.user_id %>
+                <ul class="post__bottom_box__admin_actions">
                   <li>編集</li>
                   <li>削除</li>
-                <% end %>
                 </ul>
+                <% end %>
               </div>
             </div>
           </li>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -35,10 +35,10 @@
                   </li>
                 </ul>
                 <% if user_signed_in? && current_user.id == post.user_id %>
-                <ul class="post__bottom_box__admin_actions">
-                  <li>編集</li>
-                  <li>削除</li>
-                </ul>
+                  <ul class="post__bottom_box__admin_actions">
+                    <li>編集</li>
+                    <li>削除</li>
+                  </ul>
                 <% end %>
               </div>
             </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -17,7 +17,7 @@
                   <span>投稿者：<%= post.user.name %></span>
                 </div>
                 <div class="post__top_box__time">
-                  <span>投稿日時：<%= post.created_at %></span>
+                  <span>投稿日時：<%= post.created_at.strftime("%Y-%m-%d %H:%M:%S") %></span>
                 </div>
               </div>  
               <div class="post__middle_box">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -17,7 +17,7 @@
                   <span>投稿者：<%= post.user.name %></span>
                 </div>
                 <div class="post__top_box__time">
-                  <span>投稿日時：<%= post.created_at.strftime("%Y-%m-%d %H:%M:%S") %></span>
+                  <span>投稿日時：<%= l post.created_at %></span>
                 </div>
               </div>  
               <div class="post__middle_box">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -14,14 +14,14 @@
             <div class="post">
               <div class="post__top_box">
                 <div class="post__top_box__name">
-                  <span>投稿者：投稿者名</span>
+                  <span>投稿者：<%= post.user.name %></span>
                 </div>
                 <div class="post__top_box__time">
-                  <span>投稿日時：投稿日時</span>
+                  <span>投稿日時：<%= post.created_at %></span>
                 </div>
               </div>  
               <div class="post__middle_box">
-                <span>投稿内容</span>
+                <span><%= post.content %></span>
               </div>
               <div class="post__bottom_box">
                 <ul class="post__bottom_box__user_actions">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,41 +6,45 @@
   </div>
   <div class="post_wrapper__content">
     <ul class="post_wrapper__content__post_list">
-      <%# 未投稿の場合は「まだ投稿されたスレッドはありません。」と表示するように条件分岐すること %>
-      <%# each文で投稿一覧を表示すること %>
-      <li>
-        <div class="post">
-          <div class="post__top_box">
-            <div class="post__top_box__name">
-              <span>投稿者：投稿者名</span>
+      <% if @posts.count == 0 %>
+        <li>まだ投稿されたスレッドはありません。</li>
+      <% else %>
+        <% @posts.each do |post| %>
+          <li>
+            <div class="post">
+              <div class="post__top_box">
+                <div class="post__top_box__name">
+                  <span>投稿者：投稿者名</span>
+                </div>
+                <div class="post__top_box__time">
+                  <span>投稿日時：投稿日時</span>
+                </div>
+              </div>  
+              <div class="post__middle_box">
+                <span>投稿内容</span>
+              </div>
+              <div class="post__bottom_box">
+                <ul class="post__bottom_box__user_actions">
+                  <li>
+                    <i class="far fa-comment-alt"></i>
+                    <span>コメント数</span>
+                  </li>
+                  <li>
+                    <i class="far fa-heart"></i>
+                    <span>いいね数</span>
+                  </li>
+                </ul>
+                <ul class="post__bottom_box__admin_actions">
+                <% if user_signed_in? && current_user.id == post.user_id %>
+                  <li>編集</li>
+                  <li>削除</li>
+                <% end %>
+                </ul>
+              </div>
             </div>
-            <div class="post__top_box__time">
-              <span>投稿日時：投稿日時</span>
-            </div>
-          </div>  
-          <div class="post__middle_box">
-            <span>投稿内容</span>
-          </div>
-          <div class="post__bottom_box">
-            <ul class="post__bottom_box__user_actions">
-              <li>
-                <i class="far fa-comment-alt"></i>
-                <span>コメント数</span>
-              </li>
-              <li>
-                <i class="far fa-heart"></i>
-                <span>いいね数</span>
-              </li>
-            </ul>
-            <ul class="post__bottom_box__admin_actions">
-            <% if user_signed_in? && current_user.id == post.user_id %>
-              <li>編集</li>
-              <li>削除</li>
-            <% end %>
-            </ul>
-          </div>
-        </div>
-      </li>
+          </li>
+        <% end %>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -33,8 +33,10 @@
               </li>
             </ul>
             <ul class="post__bottom_box__admin_actions">
+            <% if user_signed_in? && current_user.id == post.user_id %>
               <li>編集</li>
               <li>削除</li>
+            <% end %>
             </ul>
           </div>
         </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module OurBoard
     config.load_defaults 5.2
 
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,3 +3,6 @@ ja:
     attributes:
       post:
         content: 投稿内容
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"


### PR DESCRIPTION
# What
- 掲示板を一覧で表示できる
- 投稿者だけにスレッドの表示・削除のリンクが表示される
- 未ログイン時にも閲覧できる
- N+1問題を発生させていない（include）
- 投稿者名・投稿内容・投稿時間をそれぞれ表示させる
- 投稿時間のUTC表示を削除

## ログイン中のユーザーは「マエダアオイ」
### 編集・削除のリンクが表示されていることが分かります。
[![Image from Gyazo](https://i.gyazo.com/3f2957226640cb80ed8dd240a7b9adf8.png)](https://gyazo.com/3f2957226640cb80ed8dd240a7b9adf8)